### PR TITLE
allow name to include its own ext

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -2,6 +2,8 @@ var path = require('path');
 var fse = require('fs-extra');
 var _ = require('lodash');
 
+var extname = path.extname;
+
 var manifestMap = {};
 
 function ManifestPlugin(opts) {
@@ -51,7 +53,9 @@ ManifestPlugin.prototype.apply = function(compiler) {
         var name = chunk.name ? chunk.name : null;
 
         if (name) {
-          name = name + '.' + this.getFileType(path);
+          name = extname(name)
+            ? name
+            : name + '.' + this.getFileType(path);
         } else {
           // For nameless chunks, just map the files directly.
           name = path;


### PR DESCRIPTION
Don't append a file extension if the name already includes one.