### PR TITLE
Check existence of some webpack compilation hooks

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -187,9 +187,9 @@ ManifestPlugin.prototype.apply = function(compiler) {
       }
     }
 
-    if (compiler.hooks) {
+    if (compiler.hooks && compiler.hooks.webpackManifestPluginAfterEmit) {
       compiler.hooks.webpackManifestPluginAfterEmit.call(manifest);
-    } else {
+    } else if (compilation.applyPluginsAsync) {
       compilation.applyPluginsAsync('webpack-manifest-plugin-after-emit', manifest, compileCallback);
     }
   }.bind(this);


### PR DESCRIPTION
In webpack-dev-server, some compilation hooks may be undefined. Added checks to ensure their existence.