### PR TITLE
Fix mini-css-extract-plugin 0.4.3 issue

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -40,7 +40,7 @@ ManifestPlugin.prototype.apply = function(compiler) {
   var outputName = path.relative(outputFolder, outputFile);
 
   var moduleAsset = function (module, file) {
-    if (module.userRequest) {
+    if (module.userRequest && !moduleAssets[file]) {
       moduleAssets[file] = path.join(
         path.dirname(file),
         path.basename(module.userRequest)

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -40,12 +40,27 @@ ManifestPlugin.prototype.apply = function(compiler) {
   var outputName = path.relative(outputFolder, outputFile);
 
   var moduleAsset = function (module, file) {
-    if (module.userRequest && !moduleAssets[file]) {
+    if (module.userRequest) {
       moduleAssets[file] = path.join(
         path.dirname(file),
         path.basename(module.userRequest)
       );
     }
+  };
+
+  var normalModuleLoader = function (loaderContext, module) {
+    const { emitFile } = loaderContext;
+
+    loaderContext.emitFile = (file, content, sourceMap) => {
+      if (module.userRequest && !moduleAssets[file]) {
+        moduleAssets[file] = path.join(
+          path.dirname(file),
+          path.basename(module.userRequest)
+        );
+      }
+
+      return emitFile.call(module, file, content, sourceMap);
+    };
   };
 
   var emit = function(compilation, compileCallback) {
@@ -212,7 +227,7 @@ ManifestPlugin.prototype.apply = function(compiler) {
     compiler.hooks.webpackManifestPluginAfterEmit = new SyncWaterfallHook(['manifest']);
 
     compiler.hooks.compilation.tap(pluginOptions, function (compilation) {
-      compilation.hooks.moduleAsset.tap(pluginOptions, moduleAsset);
+      compilation.hooks.normalModuleLoader.tap(pluginOptions, normalModuleLoader);
     });
     compiler.hooks.emit.tap(pluginOptions, emit);
 


### PR DESCRIPTION
Resolves https://github.com/danethurber/webpack-manifest-plugin/issues/167

mini-css-extract-plugin reports additional, incorrect information for files that are refenced in CSS. The first time we see the file the `module.userRequest` is correct, and we add to `moduleAssets` correctly. However mini-css-extract-plugin then also reports the same `file` but with `module.userRequest` set to the CSS file that references it, which caused us to overwrite the good value in `moduleAssets`.

See the change in mini-css-extract-plugin that caused this https://github.com/webpack-contrib/mini-css-extract-plugin/pull/177