### PR TITLE
Fix missing array in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Sort files before they are passed to `generate`. [FileDescriptor typings](#filed
 
 ### `options.generate`
 
-Type: `Function(Object, FileDescriptor): Object`<br>
+Type: `Function(Object, FileDescriptor[]): Object`<br>
 Default: `(seed, files) => files.reduce((manifest, {name, path}) => ({...manifest, [name]: path}), seed)`
 
 Create the manifest. It can return anything as long as it's serialisable by `JSON.stringify`. [FileDescriptor typings](#filedescriptor)

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Modify files details before the manifest is created. [FileDescriptor typings](#f
 
 ### `options.sort`
 
-Type: `Function(FileDescriptor): number`
+Type: `Function(FileDescriptor, FileDescriptor): number`
 
 Sort files before they are passed to `generate`. [FileDescriptor typings](#filedescriptor)
 


### PR DESCRIPTION
The readme currently has (at least two) errors:
`sort` functions should have two arguments
the second argument for `generate` should be an array