### PR TITLE
feat: Group files by entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,25 @@ Default: `false`
 
 If set to `true` will emit to build folder and memory in combination with `webpack-dev-server`
 
+### `options.groupByEntry`
+
+Type: `Boolean`<br>
+Default: `false`
+
+If set to `true` will group the manifest by entry. For example, an entry object of `app` and `store` with `optimization.splitChunks` enabled will produce:
+
+```json
+{
+  "app": {
+    "vendors~app.js": "/style/vendors~app.1234567890.js",
+    "app.js": "/style/app.0987654321.js"
+  },
+  "store": {
+    "vendors~app~store.js": "/style/vendors~app~store.1357913579.js",
+    "store.js": "/style/store.0246802468.js"
+  }
+}
+```
 
 ### `options.seed`
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -11,6 +11,7 @@ function ManifestPlugin(opts) {
     fileName: 'manifest.json',
     transformExtensions: /^(gz|map)$/i,
     writeToFileEmit: false,
+    groupByEntry: false,
     seed: null,
     filter: null,
     map: null,
@@ -167,6 +168,39 @@ ManifestPlugin.prototype.apply = function(compiler) {
         manifest[file.name] = file.path;
         return manifest;
       }, seed);
+    }
+
+    // Group the files in the manifest by entry
+    const { entry } = compilation.options;
+    if (this.opts.groupByEntry && typeof entry === 'object') {
+      const groupedManifest = {};
+      const migrated = [];
+
+      Object.keys(entry).forEach(key => {
+        groupedManifest[key] = {};
+
+        Object.keys(manifest).forEach(fileName => {
+          // Match the file to an entry by matching the file name's [name]
+          const ext = path.extname(fileName)
+          const reg = new RegExp(`${key}${ext}`);
+          if (reg.exec(fileName) !== null) {
+            // Place the file into the matching entry
+            groupedManifest[key][fileName] = manifest[fileName];
+            migrated.push(fileName);
+          }
+        });
+      });
+
+      Object.keys(manifest).forEach(fileName => {
+        if (!migrated.indexOf(fileName) === -1) {
+          if (!groupedManifest.other) {
+            groupedManifest.other = {};
+          }
+          groupedManifest.other[fileName] = manifest[fileName];
+        }
+      });
+
+      manifest = groupedManifest;
     }
 
     const isLastEmit = emitCount === 0

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -842,4 +842,27 @@ describe('ManifestPlugin', function() {
       });
     });
   });
+
+  it('can group the files by entry', function(done) {
+    webpackCompile({
+      context: __dirname,
+      entry: {
+        one: './fixtures/file.js',
+        two: './fixtures/file-two.js'
+      },
+      output: {
+        filename: '[name].[hash].js'
+      }
+    }, {
+      manifestOptions: {
+        groupByEntry: true
+      }
+    }, function(manifest) {
+      expect(manifest.one).toBeDefined();
+      expect(manifest.one['one.js']).toMatch(/^one\.\w+\.js$/);
+      expect(manifest.two['two.js']).toMatch(/^two\.\w+\.js$/);
+
+      done();
+    });
+  });
 });


### PR DESCRIPTION
These changes add a new option called `groupByEntry`.

When enabled the manifest will be grouped by each key in the entry if it's an object.

The following config:

```js
{
  entry: {
    app: './app.js',
    store: './store.js'
  },
  ...
  optimization: {
    splitChunks: { chunks: 'all' }
  }
}
```

Will produce:

```json
{
  "app": {
    "vendors~app.js": "/style/vendors~app.1234567890.js",
    "app.js": "/style/app.0987654321.js"
  },
  "store": {
    "vendors~app~store.js": "/style/vendors~app~store.1357913579.js",
    "store.js": "/style/store.0246802468.js"
  }
}
```

Looks like this was actually already suggested in a similar PR by @jacobwindsor https://github.com/danethurber/webpack-manifest-plugin/pull/113#issuecomment-355940245.

Added a unit test that proves that the manifest will match this use case.