### PR TITLE
Read publicPath from stats to handle [hash]

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -33,10 +33,11 @@ const emitHook = function emit(
   compilation
 ) {
   const emitCount = emitCountMap.get(manifestFileName) - 1;
-  const publicPath =
-    options.publicPath !== null ? options.publicPath : compilation.options.output.publicPath;
   // Disable everything we don't use, add asset info, show cached assets
-  const stats = compilation.getStats().toJson({ all: false, assets: true, cachedAssets: true });
+  const stats = compilation
+    .getStats()
+    .toJson({ all: false, assets: true, cachedAssets: true, publicPath: true });
+  const publicPath = options.publicPath !== null ? options.publicPath : stats.publicPath;
   const { basePath, removeKeyHash } = options;
 
   emitCountMap.set(manifestFileName, emitCount);

--- a/test/unit/paths.js
+++ b/test/unit/paths.js
@@ -72,7 +72,26 @@ test('prefixes paths with a public path', async (t) => {
   });
 });
 
-test('is possible to overrides publicPath', async (t) => {
+test('prefixes paths with a public path and handle [hash] from public path', async (t) => {
+  const config = {
+    context: __dirname,
+    entry: {
+      one: '../fixtures/file.js'
+    },
+    output: {
+      filename: '[name].js',
+      path: join(outputPath, 'public-hash'),
+      publicPath: '/[hash]/app/'
+    }
+  };
+  const { manifest, stats } = await compile(config, t);
+
+  t.deepEqual(manifest, {
+    'one.js': `/${stats.hash}/app/one.js`
+  });
+});
+
+test('is possible to override publicPath', async (t) => {
   const config = {
     context: __dirname,
     entry: {


### PR DESCRIPTION
This is a PR related to this issue I reported earlier: https://github.com/danethurber/webpack-manifest-plugin/issues/214

The fix is pretty straight forward, read publicPath from stats in order to handle the [hash] placeholders.

