### PR TITLE
In some cases, the file path resolution is incorrect

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -163,7 +163,9 @@ ManifestPlugin.prototype.apply = function(compiler) {
       // output.publicPath turns require('foo/bar') into '/public/foo/bar', see
       // https://github.com/webpack/docs/wiki/configuration#outputpublicpath
       files = files.map(function(file) {
-        file.path = publicPath + file.path;
+        // When the public path does not end with / or start with https://cdn.example.com
+        // will produce the wrong path
+        file.path = publicPath.replace(/\/$/, '') + path.join('/', file.path);
         return file;
       }.bind(this));
     }


### PR DESCRIPTION
publicPath: '//cdn.example.com'
===>
manifest:

//cdn.example.commain.js
//cdn.example.commain.css