### PR TITLE
Fix deprecated API calls and update tests

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,6 +1,7 @@
 var path = require('path');
 var fse = require('fs-extra');
 var _ = require('lodash');
+var NormalModule = require('webpack/lib/NormalModule');
 
 const emitCountMap = new Map();
 const compilerHookMap = new WeakMap();
@@ -91,19 +92,21 @@ ManifestPlugin.prototype.apply = function(compiler) {
         cachedAssets: true,
     });
 
-    var files = compilation.chunks.reduce(function(files, chunk) {
-      return chunk.files.reduce(function (files, path) {
+    var files = [];
+    compilation.chunks.forEach(function(chunk) {
+      const chunkFiles = [];
+      chunk.files.forEach(function(filePath) {
         var name = chunk.name ? chunk.name : null;
 
         if (name) {
-          name = name + '.' + this.getFileType(path);
+          name = name + '.' + this.getFileType(filePath);
         } else {
           // For nameless chunks, just map the files directly.
-          name = path;
+          name = filePath;
         }
 
-        return files.concat({
-          path: path,
+        chunkFiles.push({
+          path: filePath,
           chunk: chunk,
           name: name,
           isInitial: chunk.isOnlyInitial(),
@@ -111,8 +114,9 @@ ManifestPlugin.prototype.apply = function(compiler) {
           isAsset: false,
           isModuleAsset: false
         });
-      }.bind(this), files);
-    }.bind(this), []);
+      }.bind(this));
+      files = files.concat(chunkFiles);
+    }.bind(this));
 
     // module assets don't show up in assetsByChunkName.
     // we're getting them this way;
@@ -243,7 +247,13 @@ ManifestPlugin.prototype.apply = function(compiler) {
   }
 
   compiler.hooks.compilation.tap(pluginOptions, function (compilation) {
-    compilation.hooks.normalModuleLoader.tap(pluginOptions, normalModuleLoader);
+    // Check for webpack v5 compilation hooks API
+    if (typeof NormalModule.getCompilationHooks === "function") {
+      NormalModule.getCompilationHooks(compilation).loader.tap(pluginOptions, normalModuleLoader);
+    } else {
+      // Deprecated in webpack v5
+      compilation.hooks.normalModuleLoader.tap(pluginOptions, normalModuleLoader);
+    }
   });
   compiler.hooks.emit.tap(pluginOptions, emit);
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=6.11.5"
   },
   "peerDependencies": {
-    "webpack": "4"
+    "webpack": ">=4"
   },
   "devDependencies": {
     "@svgr/webpack": "^4.3.3",
@@ -26,7 +26,7 @@
     "react": "^16.9.0",
     "rimraf": "^3.0.0",
     "style-loader": "^1.0.0",
-    "webpack": "^4.41.0"
+    "webpack": "^5.4.0"
   },
   "files": [
     "index.js",

--- a/spec/plugin.integration.spec.js
+++ b/spec/plugin.integration.spec.js
@@ -66,6 +66,7 @@ describe('ManifestPlugin using real fs', function() {
       webpackCompile({
         context: __dirname,
         output: {
+          publicPath: '',
           filename: '[name].js',
           path: path.join(__dirname, 'output/single-file')
         },
@@ -89,6 +90,7 @@ describe('ManifestPlugin using real fs', function() {
       webpackCompile({
         context: __dirname,
         output: {
+          publicPath: '',
           filename: '[name].js',
           path: path.join(__dirname, 'output/single-file')
         },
@@ -147,6 +149,7 @@ describe('ManifestPlugin using real fs', function() {
       webpackCompile({
         context: __dirname,
         output: {
+          publicPath: '',
           filename: '[name].js',
           path: path.join(__dirname, 'output/single-file')
         },
@@ -183,6 +186,7 @@ describe('ManifestPlugin using real fs', function() {
       compiler = webpackWatch({
         context: __dirname,
         output: {
+          publicPath: '',
           filename: '[name].[hash].js',
           path: path.join(__dirname, 'output/watch-mode')
         },
@@ -231,6 +235,7 @@ describe('ManifestPlugin using real fs', function() {
       compiler = webpackWatch({
         context: __dirname,
         output: {
+          publicPath: '',
           filename: '[name].js',
           path: path.join(__dirname, 'output/watch-import-chunk')
         },
@@ -246,19 +251,11 @@ describe('ManifestPlugin using real fs', function() {
         expect(manifest).toBeDefined();
 
         if (isFirstRun) {
-          if (isWebpackVersionGte(5)) {
-            expect(manifest).toEqual({
-              'main.js': 'main.js',
-              '0.js': '0.js',
-              '2.js': '2.js'
-            });
-          } else {
-            expect(manifest).toEqual({
-              'main.js': 'main.js',
-              '1.js': '1.js',
-              '2.js': '2.js'
-            });
-          }
+          expect(manifest).toEqual({
+            'main.js': 'main.js',
+            '1.js': '1.js',
+            '2.js': '2.js'
+          });
 
           isFirstRun = false;
           fse.outputFileSync(path.join(__dirname, 'output/watch-import-chunk/index.js'), 'import(\'./chunk1\')');
@@ -294,6 +291,7 @@ describe('ManifestPlugin using real fs', function() {
       webpackCompile(Array.from({length: nbCompiler}).map((x, i) => ({
         context: __dirname,
         output: {
+          publicPath: '',
           filename: '[name].js',
           path: path.join(__dirname, 'output/multiple-compilation')
         },
@@ -332,6 +330,7 @@ describe('ManifestPlugin using real fs', function() {
         {
           context: __dirname,
           output: {
+            publicPath: '',
             filename: '[name].js',
             path: path.join(__dirname, 'output/multiple-manifest/1')
           },
@@ -344,6 +343,7 @@ describe('ManifestPlugin using real fs', function() {
         }, {
           context: __dirname,
           output: {
+            publicPath: '',
             filename: '[name].js',
             path: path.join(__dirname, 'output/multiple-manifest/2')
           },
@@ -384,6 +384,7 @@ describe('ManifestPlugin using real fs', function() {
           entry: './fixtures/file.js',
           output: {
             path: path.join(__dirname, 'output/relative-manifest'),
+            publicPath: '',
             filename: '[name].js'
           },
           plugins: [
@@ -416,6 +417,7 @@ describe('ManifestPlugin using real fs', function() {
           entry: './fixtures/file.js',
           output: {
             path: path.join(__dirname, 'output/absolute-manifest'),
+            publicPath: '',
             filename: '[name].js'
           },
           plugins: [
@@ -449,6 +451,7 @@ describe('ManifestPlugin with memory-fs', function() {
       webpackCompile({
         context: __dirname,
         output: {
+          publicPath: '',
           filename: '[name].js',
           path: path.join(__dirname, 'output/emit')
         },
@@ -505,6 +508,7 @@ describe('scoped hoisting', function() {
         ],
       },
       output: {
+        publicPath: '',
         filename: '[name].[hash].js',
         path: path.join(__dirname, 'output/scoped-hoisting')
       },

--- a/spec/plugin.spec.js
+++ b/spec/plugin.spec.js
@@ -16,6 +16,7 @@ function webpackConfig (webpackOpts, opts) {
   var defaults = {
     output: {
       path: OUTPUT_DIR,
+      publicPath: '',
       filename: '[name].js'
     },
     plugins: [
@@ -124,13 +125,20 @@ describe('ManifestPlugin', function() {
           one: './fixtures/file.js',
         },
         output: {
+          publicPath: '',
           filename: '[name].js'
         }
       }, {}, function(manifest, stats) {
-        expect(manifest).toEqual({
-          'one.js': 'one.js',
-          'one.js.map': 'one.js.map'
-        });
+        if (isWebpackVersionGte(5)) {
+          expect(manifest).toEqual({
+            'one.js': 'one.js',
+          });
+        } else {
+          expect(manifest).toEqual({
+            'one.js': 'one.js',
+            'one.js.map': 'one.js.map'
+          });
+        }
 
         done();
       });
@@ -143,6 +151,7 @@ describe('ManifestPlugin', function() {
           one: './fixtures/file.js',
         },
         output: {
+          publicPath: '',
           filename: '[name].[hash].js'
         }
       }, {
@@ -166,6 +175,7 @@ describe('ManifestPlugin', function() {
             one: './fixtures/file.js',
           },
           output: {
+            publicPath: '',
             filename: '[name].[hash].js',
             publicPath: '/app/'
           }
@@ -185,6 +195,7 @@ describe('ManifestPlugin', function() {
             one: './fixtures/file.js',
           },
           output: {
+            publicPath: '',
             filename: '[name].[hash].js',
             publicPath: '/app/'
           }
@@ -209,6 +220,7 @@ describe('ManifestPlugin', function() {
           one: './fixtures/file.js',
         },
         output: {
+          publicPath: '',
           filename: '[name].[hash].js',
           publicPath: '/app/'
         }
@@ -232,6 +244,7 @@ describe('ManifestPlugin', function() {
           one: './fixtures/file.js',
         },
         output: {
+          publicPath: '',
           filename: '[name].js'
         }
       }, {
@@ -254,6 +267,7 @@ describe('ManifestPlugin', function() {
           one: './fixtures/file.js',
         },
         output: {
+          publicPath: '',
           filename: '[name].js',
           publicPath: 'http://www/example.com/',
         }
@@ -273,6 +287,7 @@ describe('ManifestPlugin', function() {
           one: './fixtures/file.js',
         },
         output: {
+          publicPath: '',
           filename: '[name].js'
         }
       }, {
@@ -298,6 +313,7 @@ describe('ManifestPlugin', function() {
           one: './fixtures/file.js',
         },
         output: {
+          publicPath: '',
           filename: '[name].[hash].js',
           publicPath: '/app/'
         }
@@ -445,6 +461,7 @@ describe('ManifestPlugin', function() {
           ]
         },
         output: {
+          publicPath: '',
           filename: '[name].js'
         },
         module: {
@@ -482,6 +499,7 @@ describe('ManifestPlugin', function() {
           nameless: './fixtures/nameless.js'
         },
         output: {
+          publicPath: '',
           filename: '[name].[hash].js'
         }
       }, {}, function(manifest, stats) {
@@ -550,6 +568,7 @@ describe('ManifestPlugin', function() {
           nameless: './fixtures/nameless.js'
         },
         output: {
+          publicPath: '',
           filename: '[name].[hash].js'
         }
       }, {
@@ -573,6 +592,7 @@ describe('ManifestPlugin', function() {
         context: __dirname,
         entry: './fixtures/file.js',
         output: {
+          publicPath: '',
           filename: '[name].js'
         }
       }, {
@@ -596,6 +616,7 @@ describe('ManifestPlugin', function() {
         context: __dirname,
         entry: './fixtures/file.js',
         output: {
+          publicPath: '',
           filename: 'javascripts/main.js'
         }
       }, {
@@ -624,6 +645,7 @@ describe('ManifestPlugin', function() {
           two: './fixtures/file-two.js'
         },
         output: {
+          publicPath: '',
           filename: '[name].js'
         }
       }, {
@@ -651,6 +673,7 @@ describe('ManifestPlugin', function() {
         context: __dirname,
         entry: './fixtures/file.js',
         output: {
+          publicPath: '',
           filename: '[name].js'
         }
       }, {
@@ -682,6 +705,7 @@ describe('ManifestPlugin', function() {
         context: __dirname,
         entry: './fixtures/file.js',
         output: {
+          publicPath: '',
           filename: '[name].js'
         }
       }, {
@@ -710,6 +734,7 @@ describe('ManifestPlugin', function() {
         context: __dirname,
         entry: './fixtures/file.js',
         output: {
+          publicPath: '',
           filename: '[name].js'
         }
       }, {
@@ -803,6 +828,7 @@ describe('ManifestPlugin', function() {
           one: './fixtures/file.js',
         },
         output: {
+          publicPath: '',
           filename: '[name].[hash].js',
           publicPath: '/app/'
         },
@@ -829,6 +855,7 @@ describe('ManifestPlugin', function() {
           one: './fixtures/file.js',
         },
         output: {
+          publicPath: '',
           filename: '[name].[hash].js'
         },
         plugins: [


### PR DESCRIPTION
This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

### Description

Some of the internal APIs were deprecated in webpack v5. There are two warnings:

```
(node:45864) [DEP_WEBPACK_COMPILATION_NORMAL_MODULE_LOADER_HOOK] DeprecationWarning: Compilation.hooks.normalModuleLoader was moved to NormalModule.getCompilationHooks(compilation).loader
    at getNormalModuleLoader (./node_modules/webpack/lib/Compilation.js:297:39)
    at Object.get normalModuleLoader [as normalModuleLoader] (./node_modules/webpack/lib/Compilation.js:603:12)
    at ./node_modules/webpack-manifest-plugin/lib/plugin.js:246:23
    ...
```

and

```
(node:45864) [DEP_WEBPACK_DEPRECATION_ARRAY_TO_SET] DeprecationWarning: Compilation.chunks was changed from Array to Set (using Array method 'reduce' is deprecated)
    at Set.set.<computed> [as reduce] (./node_modules/webpack/lib/util/deprecation.js:85:4)
    at ManifestPlugin.<anonymous> (./node_modules/webpack-manifest-plugin/lib/plugin.js:94:36)
   ...
```

After fixing warnings some of the tests started to fail. I think it was because of bug in webpack, but i'm not sure. It seems that webpack adds prefix `auto` to asset path, so manifest looks like this:

```json
{ "main.js": "automain.js" }
```

Probably this was caused by new placeholders `[base]` or `[path]` for file-based templates, because they have value `"auto"` by default.