### PR TITLE
feat: fallback to asset.info.sourceFilename

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -25,7 +25,7 @@ const getFileType = (fileName, { transformExtensions }) => {
 };
 
 const reduceAssets = (files, asset, moduleAssets) => {
-  const name = moduleAssets[asset.name];
+  const name = moduleAssets[asset.name] ?? asset.info.sourceFilename;
   if (name) {
     return files.concat({
       path: asset.name,

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -25,7 +25,7 @@ const getFileType = (fileName, { transformExtensions }) => {
 };
 
 const reduceAssets = (files, asset, moduleAssets) => {
-  const name = moduleAssets[asset.name] ?? asset.info.sourceFilename;
+  const name = moduleAssets[asset.name] ? moduleAssets[asset.name] : asset.info.sourceFilename;
   if (name) {
     return files.concat({
       path: asset.name,


### PR DESCRIPTION
This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

### Description

In response to and support of:
[Docs(api): add asset info for sourceFilename and javascriptModule #4116](https://github.com/webpack/webpack.js.org/pull/4116)
[feat: added `sourceFilename` with original file to asset info ](https://github.com/webpack-contrib/copy-webpack-plugin/pull/542)

Easing:
[Allow adding metadata to info #538](https://github.com/webpack-contrib/copy-webpack-plugin/issues/538)
