### PR TITLE
README: Remove broken “evergreen 🌲” link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A Webpack plugin for generating an asset manifest.
 
 ## Requirements
 
-`webpack-manifest-plugin` is an [evergreen 🌲](./.github/FAQ.md#what-does-evergreen-mean) module.
+`webpack-manifest-plugin` is an evergreen 🌲 module.
 
 This module requires an [Active LTS](https://github.com/nodejs/Release) Node version (v10.0.0+) and Webpack v4.44.0+.
 


### PR DESCRIPTION
I assume this was copied from https://github.com/shellscape/webpack-plugin-serve/blob/master/.github/FAQ.md#what-does-evergreen-mean.

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other
