### PR TITLE
Allow node 10.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "bugs": "https://github.com/shellscape/webpack-manifest-plugin/issues",
   "main": "lib/index.js",
   "engines": {
-    "node": ">=10.22.1"
+    "node": ">=10.19.0"
   },
   "scripts": {
     "ci:coverage": "nyc npm run ci:test && nyc report --reporter=text-lcov > coverage.lcov",


### PR DESCRIPTION
This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [x] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

### Description

The minimum node version was bumped in #223, which intended to bump to node >=10, but didn't mention which minor of it.

10.19 is the version shipped with Ubuntu 20.04LTS.

It would be great to allow it, to save ppl from installing yet another ppa if this is not strictly needed.