### PR TITLE
Fixing extra and invalid paths in Webpack 5

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -26,14 +26,12 @@ const getFileType = (fileName, { transformExtensions }) => {
   return transformExtensions.test(extension) ? `${split.pop()}.${extension}` : extension;
 };
 
-const reduceAssets = (files, asset, moduleAssets, assetTypeModuleAssets) => {
+const reduceAssets = (files, asset, moduleAssets) => {
   let name;
   if (moduleAssets[asset.name]) {
     name = moduleAssets[asset.name];
-  } else if (assetTypeModuleAssets[asset.info.sourceFilename]) {
-    name = join(dirname(asset.name), assetTypeModuleAssets[asset.info.sourceFilename]);
-  } else {
-    name = asset.info.sourceFilename;
+  } else if (asset.info.sourceFilename) {
+    name = join(dirname(asset.name), basename(asset.info.sourceFilename));
   }
 
   if (name) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,3 +1,5 @@
+const { dirname, join, basename } = require('path');
+
 const generateManifest = (compilation, files, { generate, seed = {} }) => {
   let result;
   if (generate) {
@@ -24,8 +26,16 @@ const getFileType = (fileName, { transformExtensions }) => {
   return transformExtensions.test(extension) ? `${split.pop()}.${extension}` : extension;
 };
 
-const reduceAssets = (files, asset, moduleAssets) => {
-  const name = moduleAssets[asset.name] ? moduleAssets[asset.name] : asset.info.sourceFilename;
+const reduceAssets = (files, asset, moduleAssets, assetTypeModuleAssets) => {
+  let name;
+  if (moduleAssets[asset.name]) {
+    name = moduleAssets[asset.name];
+  } else if (assetTypeModuleAssets[asset.info.sourceFilename]) {
+    name = join(dirname(asset.name), assetTypeModuleAssets[asset.info.sourceFilename]);
+  } else {
+    name = asset.info.sourceFilename;
+  }
+
   if (name) {
     return files.concat({
       path: asset.name,
@@ -52,29 +62,43 @@ const reduceAssets = (files, asset, moduleAssets) => {
   });
 };
 
-const reduceChunk = (files, chunk, options) =>
-  Array.of(...Array.from(chunk.files), ...Array.from(chunk.auxiliaryFiles || [])).reduce(
-    (prev, path) => {
-      let name = chunk.name ? chunk.name : null;
-      // chunk name, or for nameless chunks, just map the files directly.
-      name = name
-        ? options.useEntryKeys && !path.endsWith('.map')
-          ? name
-          : `${name}.${getFileType(path, options)}`
-        : path;
+const reduceChunk = (files, chunk, options, auxiliaryFiles) => {
+  // auxiliary files contain things like images, fonts AND, most
+  // importantly, other files like .map sourcemap files
+  // we modify the auxiliaryFiles so that we can add any of these
+  // to the manifest that was not added by another method
+  // (sourcemaps files are not added via any other method)
+  Array.from(chunk.auxiliaryFiles || []).forEach((auxiliaryFile) => {
+    auxiliaryFiles[auxiliaryFile] = {
+      path: auxiliaryFile,
+      name: basename(auxiliaryFile),
+      isInitial: false,
+      isChunk: false,
+      isAsset: true,
+      isModuleAsset: true
+    };
+  });
 
-      return prev.concat({
-        path,
-        chunk,
-        name,
-        isInitial: chunk.isOnlyInitial(),
-        isChunk: true,
-        isAsset: false,
-        isModuleAsset: false
-      });
-    },
-    files
-  );
+  return Array.from(chunk.files).reduce((prev, path) => {
+    let name = chunk.name ? chunk.name : null;
+    // chunk name, or for nameless chunks, just map the files directly.
+    name = name
+      ? options.useEntryKeys && !path.endsWith('.map')
+        ? name
+        : `${name}.${getFileType(path, options)}`
+      : path;
+
+    return prev.concat({
+      path,
+      chunk,
+      name,
+      isInitial: chunk.isOnlyInitial(),
+      isChunk: true,
+      isAsset: false,
+      isModuleAsset: false
+    });
+  }, files);
+};
 
 const standardizeFilePaths = (file) => {
   const result = Object.assign({}, file);

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -1,5 +1,5 @@
 const { mkdirSync, writeFileSync } = require('fs');
-const { basename, dirname, join, relative } = require('path');
+const { basename, dirname, join } = require('path');
 
 const { SyncWaterfallHook } = require('tapable');
 const webpack = require('webpack');
@@ -33,15 +33,7 @@ const beforeRunHook = ({ emitCountMap, manifestFileName }, compiler, callback) =
 };
 
 const emitHook = function emit(
-  {
-    compiler,
-    emitCountMap,
-    manifestAssetId,
-    manifestFileName,
-    moduleAssets,
-    assetTypeModuleAssets,
-    options
-  },
+  { compiler, emitCountMap, manifestAssetId, manifestFileName, moduleAssets, options },
   compilation
 ) {
   const emitCount = emitCountMap.get(manifestFileName) - 1;
@@ -66,10 +58,7 @@ const emitHook = function emit(
   );
 
   // module assets don't show up in assetsByChunkName, we're getting them this way
-  files = stats.assets.reduce(
-    (prev, asset) => reduceAssets(prev, asset, moduleAssets, assetTypeModuleAssets),
-    files
-  );
+  files = stats.assets.reduce((prev, asset) => reduceAssets(prev, asset, moduleAssets), files);
 
   // don't add hot updates and don't add manifests from other instances
   files = files.filter(
@@ -136,23 +125,8 @@ const emitHook = function emit(
   getCompilerHooks(compiler).afterEmit.call(manifest);
 };
 
-const normalModuleLoaderHook = ({ moduleAssets, assetTypeModuleAssets }, loaderContext, module) => {
+const normalModuleLoaderHook = ({ moduleAssets }, loaderContext, module) => {
   const { emitFile } = loaderContext;
-
-  // the "emitFile" callback is never called on asset modules
-  // so, we create a different map that can be used later in the "emit" hook
-  if (['asset', 'asset/inline', 'asset/resource', 'asset/source'].includes(module.type)) {
-    // This takes the userRequest (which is an absolute path) and turns it into
-    // a relative path to the root context. This is done so that the string
-    // will match asset.info.sourceFilename in the emit hook.
-    let sourceFilename = relative(loaderContext.rootContext, module.userRequest);
-    // at this point, Windows paths use \ in their paths
-    // but in the emit hook, asset.info.sourceFilename fill have UNIX slashes
-    sourceFilename = sourceFilename.replace(/\\/g, '/');
-    Object.assign(assetTypeModuleAssets, {
-      [sourceFilename]: basename(module.userRequest)
-    });
-  }
 
   // eslint-disable-next-line no-param-reassign
   loaderContext.emitFile = (file, content, sourceMap) => {

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -1,5 +1,5 @@
 const { mkdirSync, writeFileSync } = require('fs');
-const { basename, dirname, join } = require('path');
+const { basename, dirname, join, relative } = require('path');
 
 const { SyncWaterfallHook } = require('tapable');
 const webpack = require('webpack');
@@ -33,7 +33,15 @@ const beforeRunHook = ({ emitCountMap, manifestFileName }, compiler, callback) =
 };
 
 const emitHook = function emit(
-  { compiler, emitCountMap, manifestAssetId, manifestFileName, moduleAssets, options },
+  {
+    compiler,
+    emitCountMap,
+    manifestAssetId,
+    manifestFileName,
+    moduleAssets,
+    assetTypeModuleAssets,
+    options
+  },
   compilation
 ) {
   const emitCount = emitCountMap.get(manifestFileName) - 1;
@@ -51,13 +59,17 @@ const emitHook = function emit(
 
   emitCountMap.set(manifestFileName, emitCount);
 
+  const auxiliaryFiles = {};
   let files = Array.from(compilation.chunks).reduce(
-    (prev, chunk) => reduceChunk(prev, chunk, options),
+    (prev, chunk) => reduceChunk(prev, chunk, options, auxiliaryFiles),
     []
   );
 
   // module assets don't show up in assetsByChunkName, we're getting them this way
-  files = stats.assets.reduce((prev, asset) => reduceAssets(prev, asset, moduleAssets), files);
+  files = stats.assets.reduce(
+    (prev, asset) => reduceAssets(prev, asset, moduleAssets, assetTypeModuleAssets),
+    files
+  );
 
   // don't add hot updates and don't add manifests from other instances
   files = files.filter(
@@ -65,6 +77,17 @@ const emitHook = function emit(
       !path.includes('hot-update') &&
       typeof emitCountMap.get(join(compiler.options.output.path, name)) === 'undefined'
   );
+
+  // auxiliary files are "extra" files that are probably already included
+  // in other ways. Loop over files and remove any from auxiliaryFiles
+  files.forEach((file) => {
+    delete auxiliaryFiles[file.path];
+  });
+  // if there are any auxiliaryFiles left, add them to the files
+  // this handles, specifically, sourcemaps
+  Object.keys(auxiliaryFiles).forEach((auxiliaryFile) => {
+    files = files.concat(auxiliaryFiles[auxiliaryFile]);
+  });
 
   files = files.map((file) => {
     const changes = {
@@ -113,8 +136,23 @@ const emitHook = function emit(
   getCompilerHooks(compiler).afterEmit.call(manifest);
 };
 
-const normalModuleLoaderHook = ({ moduleAssets }, loaderContext, module) => {
+const normalModuleLoaderHook = ({ moduleAssets, assetTypeModuleAssets }, loaderContext, module) => {
   const { emitFile } = loaderContext;
+
+  // the "emitFile" callback is never called on asset modules
+  // so, we create a different map that can be used later in the "emit" hook
+  if (['asset', 'asset/inline', 'asset/resource', 'asset/source'].includes(module.type)) {
+    // This takes the userRequest (which is an absolute path) and turns it into
+    // a relative path to the root context. This is done so that the string
+    // will match asset.info.sourceFilename in the emit hook.
+    let sourceFilename = relative(loaderContext.rootContext, module.userRequest);
+    // at this point, Windows paths use \ in their paths
+    // but in the emit hook, asset.info.sourceFilename fill have UNIX slashes
+    sourceFilename = sourceFilename.replace(/\\/g, '/');
+    Object.assign(assetTypeModuleAssets, {
+      [sourceFilename]: basename(module.userRequest)
+    });
+  }
 
   // eslint-disable-next-line no-param-reassign
   loaderContext.emitFile = (file, content, sourceMap) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,6 +33,7 @@ class WebpackManifestPlugin {
 
   apply(compiler) {
     const moduleAssets = {};
+    const assetTypeModuleAssets = {};
     const manifestFileName = resolve(compiler.options.output.path, this.options.fileName);
     const manifestAssetId = relative(compiler.options.output.path, manifestFileName);
     const beforeRun = beforeRunHook.bind(this, { emitCountMap, manifestFileName });
@@ -42,9 +43,10 @@ class WebpackManifestPlugin {
       manifestAssetId,
       manifestFileName,
       moduleAssets,
+      assetTypeModuleAssets,
       options: this.options
     });
-    const normalModuleLoader = normalModuleLoaderHook.bind(this, { moduleAssets });
+    const normalModuleLoader = normalModuleLoaderHook.bind(this, { moduleAssets, assetTypeModuleAssets });
     const hookOptions = {
       name: 'WebpackManifestPlugin',
       stage: Infinity

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,6 @@ class WebpackManifestPlugin {
 
   apply(compiler) {
     const moduleAssets = {};
-    const assetTypeModuleAssets = {};
     const manifestFileName = resolve(compiler.options.output.path, this.options.fileName);
     const manifestAssetId = relative(compiler.options.output.path, manifestFileName);
     const beforeRun = beforeRunHook.bind(this, { emitCountMap, manifestFileName });
@@ -43,10 +42,9 @@ class WebpackManifestPlugin {
       manifestAssetId,
       manifestFileName,
       moduleAssets,
-      assetTypeModuleAssets,
       options: this.options
     });
-    const normalModuleLoader = normalModuleLoaderHook.bind(this, { moduleAssets, assetTypeModuleAssets });
+    const normalModuleLoader = normalModuleLoaderHook.bind(this, { moduleAssets });
     const hookOptions = {
       name: 'WebpackManifestPlugin',
       stage: Infinity

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint:package": "prettier --write package.json --plugin=prettier-plugin-package",
     "posttest": "npm install webpack@^4.44.2",
     "security": "npm audit --audit-level=moderate",
-    "test": "npm run test:v4",
+    "test": "npm run test:v4 && npm run test:v5",
     "test:v4": "ava",
     "test:v5": "npm install webpack@^5.0.0 --no-save && ava"
   },

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "lint:js": "eslint --fix --cache lib test",
     "lint:json": "prettier --write codecov.yml .circleci/config.yml .eslintrc",
     "lint:package": "prettier --write package.json --plugin=prettier-plugin-package",
-    "posttest": "npm install webpack@^4.44.2",
+    "posttest": "node set-webpack-version.js \"^4.44.2\" && npm install",
     "security": "npm audit --audit-level=moderate",
     "test": "npm run test:v4 && npm run test:v5",
     "test:v4": "ava",
-    "test:v5": "npm install webpack@^5.0.0 --no-save && ava"
+    "test:v5": "node set-webpack-version.js \"^5\" && npm install && ava"
   },
   "files": [
     "lib",

--- a/set-webpack-version.js
+++ b/set-webpack-version.js
@@ -1,0 +1,25 @@
+/*
+ * This file sets Webpack version - both devDependencies and peerDependencies.
+ *
+ * This is, for some reason, needed with Windows and maybe npm 6. Running
+ * "npm install webpack -D" AND manually updating the peerDependencies
+ * (because npm 6 does not do that but npm 7 does) is not enough. For some
+ * reason why must, by hand, update the package.json file first and then
+ * run a normal "npm install".
+ */
+const fs = require('fs');
+const path = require('path');
+
+const version = process.argv[2];
+if (!version) {
+  console.log('Please pass the webpack version - "^4" or "^5" - as an argument.');
+
+  process.exit(1);
+}
+
+const packageData = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json')));
+packageData.peerDependencies.webpack = version;
+
+packageData.devDependencies.webpack = version;
+
+fs.writeFileSync(path.join(__dirname, 'package.json'), JSON.stringify(packageData, null, 2));

--- a/test/fixtures/import_image.js
+++ b/test/fixtures/import_image.js
@@ -1,0 +1,1 @@
+import '../../assets/manifest.svg';

--- a/test/integration/location.js
+++ b/test/integration/location.js
@@ -22,12 +22,12 @@ test('output to the correct location', async (t) => {
       filename: '[name].js',
       path: outputPath
     },
-    plugins: [new WebpackManifestPlugin({ fileName: 'webpack.manifest.js' })]
+    plugins: [new WebpackManifestPlugin({ fileName: 'webpack.manifest.json' })]
   };
 
   await compile(config, {}, t);
 
-  const manifestPath = join(outputPath, 'webpack.manifest.js');
+  const manifestPath = join(outputPath, 'webpack.manifest.json');
   const result = readJson(manifestPath);
 
   t.deepEqual(result, { 'main.js': 'main.js' });
@@ -41,11 +41,11 @@ test('output using absolute path', async (t) => {
       filename: '[name].js',
       path: absOutputPath
     },
-    plugins: [new WebpackManifestPlugin({ fileName: join(absOutputPath, 'webpack.manifest.js') })]
+    plugins: [new WebpackManifestPlugin({ fileName: join(absOutputPath, 'webpack.manifest.json') })]
   };
   await compile(config, {}, t);
 
-  const manifestPath = join(absOutputPath, 'webpack.manifest.js');
+  const manifestPath = join(absOutputPath, 'webpack.manifest.json');
   const result = readJson(manifestPath);
 
   t.deepEqual(result, { 'main.js': 'main.js' });

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -75,15 +75,15 @@ test('works with source maps', async (t) => {
       one: '../fixtures/file.js'
     },
     output: {
-      filename: '[name].js',
+      filename: 'build/[name].js',
       path: join(outputPath, 'source-maps')
     }
   };
   const { manifest } = await compile(config, t);
 
   t.deepEqual(manifest, {
-    'one.js': 'one.js',
-    'one.js.map': 'one.js.map'
+    'one.js': 'build/one.js',
+    'one.js.map': 'build/one.js.map'
   });
 });
 
@@ -158,11 +158,6 @@ test('outputs a manifest of no-js file', async (t) => {
     'file.txt': 'file.txt'
   };
 
-  // Note: I believe this to be another bug in webpack v5 and cannot find a good workaround atm
-  if (webpack.version.startsWith('5')) {
-    expected['main.txt'] = 'file.txt';
-  }
-
   t.truthy(manifest);
   t.deepEqual(manifest, expected);
 });
@@ -188,3 +183,35 @@ test('make manifest available to other webpack plugins', async (t) => {
     t.pass();
   }
 });
+
+if (!webpack.version.startsWith('4')) {
+  test('works with asset modules', async (t) => {
+    const config = {
+      context: __dirname,
+      entry: '../fixtures/import_image.js',
+      output: {
+        path: join(outputPath, 'auxiliary-assets'),
+        assetModuleFilename: `images/[name].[hash:4][ext]`
+      },
+      module: {
+        rules: [
+          {
+            test: /\.(svg)/,
+            type: 'asset/resource'
+          }
+        ]
+      }
+    };
+
+    const { manifest } = await compile(config, t);
+    const expected = {
+      'main.js': 'main.js',
+      'images/manifest.svg': `images/manifest.14ca.svg`
+    };
+
+    t.truthy(manifest);
+    t.deepEqual(manifest, expected);
+  });
+} else {
+  test.skip('works with asset modules', () => {});
+}

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -210,7 +210,9 @@ if (!webpack.version.startsWith('4')) {
     };
 
     t.truthy(manifest);
-    t.deepEqual(manifest, expected);
+    t.deepEqual(Object.keys(expected), ['main.js', 'images/manifest.svg']);
+    t.deepEqual(manifest['main.js'], 'main.js');
+    t.regex(manifest['images/manifest.svg'], /images\/manifest\.[a-z|\d]{4}\.svg/);
   });
 } else {
   test.skip('works with asset modules', () => {});

--- a/test/unit/manifest-location.js
+++ b/test/unit/manifest-location.js
@@ -17,7 +17,7 @@ test('relative path', async (t) => {
   };
 
   const { manifest } = await compile(config, t, {
-    fileName: 'webpack.manifest.js'
+    fileName: 'webpack.manifest.json'
   });
 
   t.deepEqual(manifest, { 'main.js': 'main.js' });
@@ -31,7 +31,7 @@ test('absolute path', async (t) => {
   };
 
   const { manifest } = await compile(config, t, {
-    fileName: join(outputPath, 'absolute/webpack.manifest.js')
+    fileName: join(outputPath, 'absolute/webpack.manifest.json')
   });
 
   t.deepEqual(manifest, { 'main.js': 'main.js' });

--- a/test/unit/paths.js
+++ b/test/unit/paths.js
@@ -2,7 +2,6 @@ const { join } = require('path');
 
 const test = require('ava');
 const del = require('del');
-const webpack = require('webpack');
 
 const { compile, hashLiteral } = require('../helpers/unit');
 
@@ -199,11 +198,6 @@ test('ensures the manifest is mapping paths to names', async (t) => {
     'main.js': 'main.js',
     'file.txt': 'outputfile.txt'
   };
-
-  // Note: I believe this to be another bug in webpack v5 and cannot find a good workaround atm
-  if (webpack.version.startsWith('5')) {
-    expected['main.txt'] = 'outputfile.txt';
-  }
 
   t.truthy(manifest);
   t.deepEqual(manifest, expected);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [X] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [X] yes
- [] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [X] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers: Fixes #238 and fixes #237 (also fixes https://github.com/symfony/webpack-encore/issues/907)

### Description

Hi!

I maintain @symfony/webpack-encore, and we recently upgraded to Webpack 5 and have hit issues with the `manifest.json` file. So, I dug into it :). 

This is complex, and I hope someone may have some ideas on how to make this nicer. Here is the situation:

A) As far as I (and the test suite) can tell, `chunk.auxiliaryFiles` is *only* needed to get sourcemap files. All other files are available in other ways. Since *all* `chunk.auxiliaryFiles` were used before, it caused #237 because when we loop over these files, we re-use the same `chunk.name` over and over again (and then just add the correct extension like `.svg`). So, we need to use *some* of these, but not all of them. To do that, we collect all the "auxiliary files", then check which have *not* been added to the manifest at the end. Those that are missing (sourcemaps) are added.

B) The second issue - and the one that fixes #238 - is more complex. Basically, if you're using the new "asset modules" system in Webpack 5, then the `emitFile()` method - which we rely on in the `normalModuleLoaderHook` is never called. In fact, as far as I can tell, this method was *only* ever called by the `file-loader` - https://github.com/webpack-contrib/file-loader/blob/467e6b782bb8bb9fcb54dcb981b5df1a2aeae818/src/index.js#L81 (`this` is the `loaderContext`) - it's never called by Webpack directly.

When you use "asset modules", there is no `file-loader` and so this is never called. According to the Webpack people - https://github.com/webpack/webpack/issues/12637#issuecomment-776185604 - we should rely on `asset.info.sourceFilename` as the "source of truth". We were already using that, but sort of "incorrectly" - the `asset.info.sourceFilename` will be equal to something like `'../../assets/logo.png'` or `'node_modules/something/fonts/lato-normal.abc123.woff2'`. So, what we need is the `basename` of this prefixed by the `dirname` of `asset.name` (which will be something like `fonts/lato-normal.abc123.woff2`).

## To test in your project

If you're having this issue, I would love if this fix could be validated:

```
yarn remove webpack-manifest-plugin
yarn add git://github.com/weaverryan/webpack-manifest-plugin.git#fix-invalid-paths-webpack5
```

Thanks!