### PR TITLE
Allow accessing compilation object in generate() callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ Allows filtering the files which make up the manifest. The passed function shoul
 Type: `Function`<br>
 Default: `undefined`
 
-A custom `Function` to create the manifest. The passed function should match the signature of `(seed: Object, files: FileDescriptor[], entries: string[]) => Object` and can return anything as long as it's serialisable by `JSON.stringify`.
+A custom `Function` to create the manifest. The passed function should match the signature of `(seed: Object, files: FileDescriptor[], entries: string[], compilation: Compilation) => Object` and can return anything as long as it's serialisable by `JSON.stringify`.
+
+Type: [`Compilation`](https://github.com/webpack/webpack/blob/master/lib/Compilation.js)
 
 ### `map`
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -6,7 +6,7 @@ const generateManifest = (compilation, files, { generate, seed = {} }) => {
       (e, [name, entrypoint]) => Object.assign(e, { [name]: entrypoint.getFiles() }),
       {}
     );
-    result = generate(seed, files, entrypoints);
+    result = generate(seed, files, entrypoints, compilation);
   } else {
     result = files.reduce(
       (manifest, file) => Object.assign(manifest, { [file.name]: file.path }),


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

### Description

This PR adds access to the [Compilation](https://github.com/webpack/webpack/blob/master/lib/Compilation.js) object in the `generate()` callback to allow working with the new `ChunkGraph` API