### PR TITLE
Support publicPath = “auto”

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -46,7 +46,14 @@ const emitHook = function emit(
     publicPath: true
   });
 
-  const publicPath = options.publicPath !== null ? options.publicPath : stats.publicPath;
+  const publicPath =
+    options.publicPath !== null
+      ? options.publicPath === 'auto'
+        ? ''
+        : options.publicPath
+      : stats.publicPath === 'auto'
+      ? ''
+      : stats.publicPath;
   const { basePath, removeKeyHash } = options;
 
   emitCountMap.set(manifestFileName, emitCount);

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -50,10 +50,10 @@ const emitHook = function emit(
   const publicPath =
     options.publicPath !== null
       ? options.publicPath === 'auto'
-        ? basePath
+        ? basePath || ''
         : options.publicPath
       : stats.publicPath === 'auto'
-      ? basePath
+      ? basePath || ''
       : stats.publicPath;
 
   emitCountMap.set(manifestFileName, emitCount);

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -46,15 +46,15 @@ const emitHook = function emit(
     publicPath: true
   });
 
+  const { basePath, removeKeyHash } = options;
   const publicPath =
     options.publicPath !== null
       ? options.publicPath === 'auto'
-        ? ''
+        ? basePath
         : options.publicPath
       : stats.publicPath === 'auto'
-      ? ''
+      ? basePath
       : stats.publicPath;
-  const { basePath, removeKeyHash } = options;
 
   emitCountMap.set(manifestFileName, emitCount);
 

--- a/test/unit/paths.js
+++ b/test/unit/paths.js
@@ -226,3 +226,21 @@ test('should output unix paths', async (t) => {
     'some/dir/main.js': 'some/dir/main.js'
   });
 });
+
+test('supports public path auto', async (t) => {
+  const config = {
+    context: __dirname,
+    entry: {
+      one: '../fixtures/file.js'
+    },
+    output: {
+      filename: `[name].${hashLiteral}.js`,
+      path: join(outputPath, 'public-auto'),
+      publicPath: 'auto'
+    }
+  };
+  const { manifest, stats } = await compile(config, t);
+  t.deepEqual(manifest, {
+    'one.js': `one.${stats.hash}.js`
+  });
+});


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
Webpack 5 introduces (I think) a default `publicPath` of `"auto"`. The idea is that things can work out an appropriate `publicPath` at runtime or based on something else. The documentation for it is https://webpack.js.org/guides/public-path/. In Webpack 5 `"auto"` is the default.

This PR uses the `basePath` as the best guess for `publicPath` if the `publicPath` is set to `"auto"`. I think that's a good best guess...