### PR TITLE
fix: properly join publicPath, basePath

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -127,12 +127,20 @@ const emitHook = function emit(
   });
 
   files = files.map((file: FileDescriptor) => {
+    const normalizePath = (path: string): string => {
+      if (!path.endsWith('/')) {
+        return `${path}/`;
+      }
+
+      return path;
+    };
+
     const changes = {
       // Append optional basepath onto all references. This allows output path to be reflected in the manifest.
-      name: basePath ? join(basePath, file.name) : file.name,
+      name: basePath ? normalizePath(basePath) + file.name : file.name,
       // Similar to basePath but only affects the value (e.g. how output.publicPath turns
       // require('foo/bar') into '/public/foo/bar', see https://github.com/webpack/docs/wiki/configuration#outputpublicpath
-      path: publicPath ? join(publicPath, file.path) : file.path
+      path: publicPath ? normalizePath(publicPath) + file.path : file.path
     };
 
     // Fixes #210

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -129,10 +129,10 @@ const emitHook = function emit(
   files = files.map((file: FileDescriptor) => {
     const changes = {
       // Append optional basepath onto all references. This allows output path to be reflected in the manifest.
-      name: basePath ? basePath + file.name : file.name,
+      name: basePath ? join(basePath, file.name) : file.name,
       // Similar to basePath but only affects the value (e.g. how output.publicPath turns
       // require('foo/bar') into '/public/foo/bar', see https://github.com/webpack/docs/wiki/configuration#outputpublicpath
-      path: publicPath ? publicPath + file.path : file.path
+      path: publicPath ? join(publicPath, file.path) : file.path
     };
 
     // Fixes #210


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

### Description

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->


When `output.publicPath` is not ends with `/`, the path of output will be incorrect.

Webpack configuration:

```javascript
output: {
   publicPath: '/public/js'
 },
```

Wrong output:

```json
{
  "index.js": "/public/jsindex.04565a72d083184c3c5a.js"
}
```

Correct output:

```json
{
  "index.js": "/public/js/index.04565a72d083184c3c5a.js"
}
```