### PR TITLE
fix: only import webpack types

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -170,11 +170,13 @@ interface LegacyModule extends Module {
   userRequest?: any;
 }
 
+
 const normalModuleLoaderHook = (
   { moduleAssets }: { moduleAssets: Record<any, any> },
-  loaderContext: LoaderContext<any>,
+  _loaderContext: object,
   module: LegacyModule
 ) => {
+  const loaderContext = _loaderContext as LoaderContext<any>;
   const { emitFile } = loaderContext;
 
   // eslint-disable-next-line no-param-reassign

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -173,13 +173,12 @@ interface LegacyModule extends Module {
 
 const normalModuleLoaderHook = (
   { moduleAssets }: { moduleAssets: Record<any, any> },
-  _loaderContext: object,
+  context: unknown,
   module: LegacyModule
 ) => {
-  const loaderContext = _loaderContext as LoaderContext<any>;
+  const loaderContext = context as LoaderContext<any>;
   const { emitFile } = loaderContext;
 
-  // eslint-disable-next-line no-param-reassign
   loaderContext.emitFile = (file: string, content: string, sourceMap: any) => {
     if (module.userRequest && !moduleAssets[file]) {
       Object.assign(moduleAssets, { [file]: join(dirname(file), basename(module.userRequest)) });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,7 @@
 import { relative, resolve } from 'path';
 
 import { SyncHook } from 'tapable';
-import { Compiler, WebpackPluginInstance, Compilation } from 'webpack';
-// @ts-ignore
-import NormalModule from 'webpack/lib/NormalModule';
-
+import type { Compiler, WebpackPluginInstance, Compilation } from 'webpack';
 import { FileDescriptor } from './helpers';
 import { beforeRunHook, emitHook, getCompilerHooks, normalModuleLoaderHook } from './hooks';
 
@@ -71,6 +68,7 @@ class WebpackManifestPlugin implements WebpackPluginInstance {
   }
 
   apply(compiler: Compiler) {
+    const { NormalModule } = compiler.webpack;
     const moduleAssets = {};
     const manifestFileName = resolve(compiler.options.output?.path || './', this.options.fileName);
     const manifestAssetId = relative(compiler.options.output?.path || './', manifestFileName);


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [x] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

### Description

So I've somehow messed with dependency tree (with monorepo+linking) and webpack loaded twise. 
While you have setup webpack as peerDep and everything should be ok, I guess better to get webpack module provided instead of importing it. Also easier ts types