### PR TITLE
fix: Pass `chunkGraph` through in `generate` function

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -35,7 +35,7 @@ const generateManifest = (
       (e, [name, entrypoint]) => Object.assign(e, { [name]: entrypoint.getFiles() }),
       {} as Record<string, any>
     );
-    result = generate(seed, files, entrypoints);
+    result = generate(seed, files, entrypoints, compilation.chunkGraph);
   } else {
     result = files.reduce(
       (manifest, file) => Object.assign(manifest, { [file.name]: file.path }),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { relative, resolve } from 'path';
 
 import { SyncHook } from 'tapable';
-import { Compiler, WebpackPluginInstance, Compilation } from 'webpack';
+import { Compiler, WebpackPluginInstance, Compilation, ChunkGraph } from 'webpack';
 // @ts-ignore
 import NormalModule from 'webpack/lib/NormalModule';
 
@@ -21,7 +21,8 @@ export interface InternalOptions {
   generate: (
     seed: Record<any, any>,
     files: FileDescriptor[],
-    entries: Record<string, string[]>
+    entries: Record<string, string[]>,
+    chunkGraph: ChunkGraph
   ) => Manifest;
   map: (file: FileDescriptor) => FileDescriptor;
   publicPath: string;

--- a/test/unit/generate.js
+++ b/test/unit/generate.js
@@ -130,3 +130,31 @@ test('should generate manifest with "entrypoints" key', async (t) => {
     }
   });
 });
+
+test('should generate manifest with chunk modules', async (t) => {
+  const config = {
+    context: __dirname,
+    entry: '../fixtures/nameless.js',
+    output: { path: join(outputPath, 'entrypoints-key') }
+  };
+
+  const { manifest } = await compile(config, t, {
+    generate: (_seed, files, _entrypoints, chunkGraph) => {
+      const chunkToIsEntryChunk = Object.fromEntries(
+        files
+          .filter((file) => file.isChunk)
+          .map((file) => [file.name, chunkGraph.getNumberOfEntryModules(file.chunk) > 0])
+      );
+      return {
+        chunkToIsEntryChunk
+      };
+    }
+  });
+
+  t.deepEqual(manifest, {
+    chunkToIsEntryChunk: {
+      'fixtures_file_js.js': false,
+      'main.js': true
+    }
+  });
+});

--- a/test/unit/generate.js
+++ b/test/unit/generate.js
@@ -135,7 +135,7 @@ test('should generate manifest with chunk modules', async (t) => {
   const config = {
     context: __dirname,
     entry: '../fixtures/nameless.js',
-    output: { path: join(outputPath, 'entrypoints-key') }
+    output: { path: join(outputPath, 'chunk-to-is-entry-chunk') }
   };
 
   const { manifest } = await compile(config, t, {


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [x] yes (_bugfixes and features will not be merged without tests_)
- [ ] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking.

List any relevant issue numbers:

### Description

Webpack 5 deprecated a lot of the APIs that exist on chunks, and instead prefers the use of the ChunkGraph API. We have a few places where we use now-deprecated APIs in our usage of the WebpackManifestPlugin, and would like to move those over to using the ChunkGraph API.

This PR passes through the `chunkGraph` in the `generate` function

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
